### PR TITLE
:sparkles: Add app ExternalDNS

### DIFF
--- a/base/external-dns/helm-release.yaml
+++ b/base/external-dns/helm-release.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: external-dns
+spec:
+  chart:
+    spec:
+      chart: external-dns
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+  interval: 1h
+  releaseName: external-dns
+  values:
+    provider: cloudflare
+    domainFilters:
+    - ffddorf.net
+    env:
+    - name: CF_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare-secret
+          key: token
+    - name: CF_API_EMAIL
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare-secret
+          key: email

--- a/base/external-dns/helm-repository.yaml
+++ b/base/external-dns/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: external-dns
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/base/external-dns/kustomization.yaml
+++ b/base/external-dns/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-dns
+resources:
+- helm-release.yaml
+- helm-repository.yaml
+- namespace.yaml

--- a/base/external-dns/namespace.yaml
+++ b/base/external-dns/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns

--- a/environments/prod/kustomization.yaml
+++ b/environments/prod/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
 - ../../base/cert-manager
 - ../../base/cryptpad
+- ../../base/external-dns
 - ../../base/grafana
 - ../../base/prometheus


### PR DESCRIPTION
With ExternalDNS, we automate managing DNS records.

This only applies for records in the domain 'ffddorf.net'. The
needed Cloudflare API token has to be created manually.