### PR TITLE
:wrench: Configure Cluster Issuer with DNS challenges

### DIFF
--- a/base/cert-manager/cluster-issuer-letsencrypt-prod.yaml
+++ b/base/cert-manager/cluster-issuer-letsencrypt-prod.yaml
@@ -11,3 +11,12 @@ spec:
     solvers:
     - http01:
         ingress: {}
+    - dns01:
+        cloudflare:
+          email: support@freifunk-duesseldorf.de
+          apiTokenSecretRef:
+            name: cloudflare-secret
+            key: token
+      selector:
+        dnsZones:
+        - ffddorf.net


### PR DESCRIPTION
Configure cert-manager's cluster issuer for Let's Encrypt with DNS
challenges.

The needed secret with a Cloudflare API token has to be created
manually.