### PR TITLE
:wrench: Configure Grafana ingress

### DIFF
--- a/base/grafana/helm-release.yaml
+++ b/base/grafana/helm-release.yaml
@@ -15,16 +15,6 @@ spec:
   values:
     serviceMonitor:
       enabled: true
-    ingress:
-      enabled: true
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-prod
-      hosts:
-      - grafana.jitsi.freifunk-duesseldorf.de
-      tls:
-      - secretName: grafana-tls
-        hosts:
-        - grafana.jitsi.freifunk-duesseldorf.de
     grafana.ini:
       auth.anonymous:
         enabled: true

--- a/clusters/k3s1/grafana-helm-release.yaml
+++ b/clusters/k3s1/grafana-helm-release.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  values:
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+      hosts:
+      - grafana.jitsi.freifunk-duesseldorf.de
+      - grafana.ffddorf.net
+      tls:
+      - secretName: grafana-tls
+        hosts:
+        - grafana.jitsi.freifunk-duesseldorf.de
+        - grafana.ffddorf.net
+   

--- a/clusters/k3s1/kustomization.yaml
+++ b/clusters/k3s1/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - flux-system
 - ../../environments/prod
 - traefik-config.yaml
+patchesStrategicMerge:
+- grafana-helm-release.yaml


### PR DESCRIPTION
This configures the Grafana ingress to also listen on grafana.ffddorf.net

Also re-arrange the ingress to appear in a cluster specific patch, in
case we want to run other instances with other hostnames.

The DNS entry and HTTP certificate should be issued automatically.