### PR TITLE
:art: Fix YAML indentation inconsistency

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+yaml-files:
+- '*.yaml'
+rules:
+  indentation:
+    spaces: 2
+    indent-sequences: false

--- a/base/cryptpad/helm-release.yaml
+++ b/base/cryptpad/helm-release.yaml
@@ -22,10 +22,10 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
       hosts:
-        - host: cryptpad.freifunk-duesseldorf.de
-        - host: pad.freifunk-duesseldorf.de
+      - host: cryptpad.freifunk-duesseldorf.de
+      - host: pad.freifunk-duesseldorf.de
       tls:
-        - hosts:
-            - cryptpad.freifunk-duesseldorf.de
-            - pad.freifunk-duesseldorf.de
-          secretName: cryptpad-tls-prod
+      - hosts:
+        - cryptpad.freifunk-duesseldorf.de
+        - pad.freifunk-duesseldorf.de
+        secretName: cryptpad-tls-prod

--- a/base/grafana/kustomization.yaml
+++ b/base/grafana/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: grafana
 resources:
- - dashboards.yaml
- - helm-release.yaml
- - helm-repository.yaml
- - namespace.yaml
+- dashboards.yaml
+- helm-release.yaml
+- helm-repository.yaml
+- namespace.yaml

--- a/base/prometheus/grafana-datasource.yaml
+++ b/base/prometheus/grafana-datasource.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: grafana-datasource-prometheus
   labels:
-     grafana_datasource: "1"
+    grafana_datasource: "1"
 data:
   datasource.yaml: |-
     apiVersion: 1

--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: prometheus
 resources:
- - grafana-datasource.yaml
- - helm-release.yaml
- - helm-repository.yaml
- - namespace.yaml
+- grafana-datasource.yaml
+- helm-release.yaml
+- helm-repository.yaml
+- namespace.yaml


### PR DESCRIPTION
Use yamllint to check for indentation inconsistencies and fix the
current findings.

All indentations should be made with 2 spaces. Sequences are not
indented, as Kubernetes suggests.

The yamllint configuration is provided for future use.