### PR TITLE
:alien: Upgrade Flux API versions in manifests

### DIFF
--- a/base/cert-manager/helm-release.yaml
+++ b/base/cert-manager/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cert-manager

--- a/base/cryptpad/helm-release.yaml
+++ b/base/cryptpad/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cryptpad

--- a/base/external-dns/helm-release.yaml
+++ b/base/external-dns/helm-release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/base/grafana/dashboards.yaml
+++ b/base/grafana/dashboards.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: grafana-dashboards-kubernetes
@@ -9,7 +9,7 @@ spec:
     branch: master
   url: https://github.com/dotdc/grafana-dashboards-kubernetes.git
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: grafana-dashboards-kubernetes

--- a/base/grafana/helm-release.yaml
+++ b/base/grafana/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: grafana

--- a/base/prometheus/helm-release.yaml
+++ b/base/prometheus/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prometheus 

--- a/base/vault/helm-release.yaml
+++ b/base/vault/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vault

--- a/clusters/k3s1/grafana-helm-release.yaml
+++ b/clusters/k3s1/grafana-helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: grafana


### PR DESCRIPTION
Upgrade the Flux API versions according to the current custom resource definitions (CRD).