### PR TITLE
feat: Configure cluster issuer for DNS

### DIFF
--- a/base/cert-manager/cluster-issuer-letsencrypt-prod.yaml
+++ b/base/cert-manager/cluster-issuer-letsencrypt-prod.yaml
@@ -13,6 +13,7 @@ spec:
     - http01:
         ingress: {}
     - dns01:
+        cnameStrategy: follow
         cloudflare:
           email: support@freifunk-duesseldorf.de
           apiTokenSecretRef:
@@ -21,3 +22,4 @@ spec:
       selector:
         dnsZones:
         - ffddorf.net
+        - freifunk-duesseldorf.de


### PR DESCRIPTION
This configures the Let's Encrypt cluster issuer to follow CNAME records
in order to determine the right zone for DNS challenges.

With this, we can issue certificates for the zone
'freifunk-duesseldorf.de' for certain hostnames without giving
cert-manager permission to edit this zone.

see-also: https://github.com/ffddorf/terraform-cloudflare-dns/pull/48
